### PR TITLE
Modify: Localize scope of color

### DIFF
--- a/visualize-penguins.R
+++ b/visualize-penguins.R
@@ -7,3 +7,8 @@ ggplot(
   data = penguins,
   mapping = aes(x = flipper_length_mm, y = body_mass_g, color = species),
 ) + geom_point()
+
+ggplot(data = penguins,
+       mapping = aes(x = flipper_length_mm, y = body_mass_g)) +
+  geom_point(mapping = aes(color = species)) +
+  geom_line('lm')


### PR DESCRIPTION
# Description
-----------------

Fixed changes in code to the following snippet to make the plot color local to points.
```r
ggplot(data = penguins,
       mapping = aes(x = flipper_length_mm, y = body_mass_g)) +
  geom_point(mapping = aes(color = species)) +
  geom_line('lm')
```