### PR TITLE
Fix: replace geom_line with geom_smooth for plot

### DIFF
--- a/visualize-penguins.R
+++ b/visualize-penguins.R
@@ -11,4 +11,4 @@ ggplot(
 ggplot(data = penguins,
        mapping = aes(x = flipper_length_mm, y = body_mass_g)) +
   geom_point(mapping = aes(color = species)) +
-  geom_line('lm')
+  geom_smooth(method = 'lm')


### PR DESCRIPTION
# Description
------------------

Modified code from `geom_line` to `geom_smooth` for plot. Changes:
```r
ggplot(data = penguins,
       mapping = aes(x = flipper_length_mm, y = body_mass_g)) +
  geom_point(mapping = aes(color = species)) +
  geom_smooth(method = 'lm')
```